### PR TITLE
Fix link to sponsor packages PDF

### DIFF
--- a/resources/badges/index.html
+++ b/resources/badges/index.html
@@ -88,7 +88,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 									c2.971,0.333,5.975,0.828,9.016,1.485c3.035,0.662,6.041,1.455,9.013,2.376C810.076,131.123,812.75,132.114,815.129,133.166z"/>
 							</g>
 							<g>
-								
+
 									<rect x="219.84" y="167.413" transform="matrix(0.7069 -0.7073 0.7073 0.7069 -74.0573 214.0025)" width="2.726" height="57.903"/>
 								<rect x="219.837" y="167.416" transform="matrix(0.7066 0.7076 -0.7076 0.7066 203.864 -98.91)" width="2.724" height="57.901"/>
 							</g>
@@ -234,7 +234,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 				</p>
 
 				<div class="button-group">
-					<a class="button button--negative" href="resources/DCNordics - Sponsoring packages.pdf">
+					<a class="button button--negative" href="../DCNordics - Sponsoring packages.pdf">
 						See sponsor packages
 					</a>
 					<a class="button button--negative" href="mailto:sponsors@drupalcampnordics.com">


### PR DESCRIPTION
The "See sponsor packages" link on http://www.drupalcampnordics.com/resources/badges/